### PR TITLE
Added experimental FastAPI-Endpoints so that openwebui can natively access this mcp server more stable. MCP isn't yet.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from a base Python image
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Start from a base Python image
 FROM python:3.12-slim
 
+# For debugging purposes, install curl
+RUN apt update && apt install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+    
 # Set the working directory
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,34 @@ If no API key is provided, the server will use unauthenticated access with lower
   - Get your key from [Semantic Scholar API](https://www.semanticscholar.org/product/api)
   - If not provided, the server will use unauthenticated access
 
+### HTTP Bridge (Built-in)
+
+This repository includes a small HTTP bridge (`semantic_scholar.bridge`) that
+exposes a minimal REST API for common workflows.
+
+Default listening port: `8000`.
+
+Available endpoints:
+
+- `GET /v1/paper/search?q=...` — paper search (params: `fields`, `offset`, `limit`)
+- `GET /v1/paper/{paper_id}` — paper details (param: `fields`)
+- `POST /v1/paper/batch` — batch paper details (JSON: `{ "ids": [ ... ] }`)
+- `GET /v1/author/search?q=...` — author search (params: `fields`, `offset`, `limit`)
+- `GET /v1/author/{author_id}` — author details (param: `fields`)
+- `POST /v1/author/batch` — batch author details (JSON: `{ "ids": [ ... ] }`)
+- `GET /v1/recommendations?paper_id=...` — recommendations for a paper
+
+The bridge reuses the package's HTTP utilities (`semantic_scholar.utils.http`)
+so rate limits, API key handling and connection pooling remain consistent with
+the MCP tools.
+
+Example:
+
+```bash
+curl 'http://localhost:8000/v1/paper/search?q=machine+learning&limit=5'
+```
+
+
 ### Rate Limits
 
 The server automatically adjusts to the appropriate rate limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@
     environment:
       - SEMANTIC_SCHOLAR_API_KEY=none
       - SEMANTIC_SCHOLAR_DEBUG=false
+      - SEMANTIC_SCHOLAR_TIMEOUT=120

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+ services:
+  semanticscholarmcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: semanticscholarmcp
+    #image: yourownnamespace/semantic-scholar-fastmcp-mcp-server:2026-01-12
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    environment:
+      - SEMANTIC_SCHOLAR_API_KEY=none
+      - SEMANTIC_SCHOLAR_DEBUG=false

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ python-dotenv>=1.0.0
 
 # Server dependencies
 uvicorn>=0.27.1
-fastmcp>=0.1.0 
+fastmcp>=2.0.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,8 @@ pytest-asyncio>=0.21.0
 python-dotenv>=1.0.0
 
 # Server dependencies
-uvicorn>=0.27.1
-fastmcp>=2.0.0 
+# Pin fastmcp<3 for stability (recommended by fastmcp docs)
+# Use uvicorn with websockets disabled to avoid deprecation warnings
+fastmcp>=2.0.0,<3.0.0
+fastapi>=0.115.0
+uvicorn>=0.32.0

--- a/semantic_scholar/api/authors.py
+++ b/semantic_scholar/api/authors.py
@@ -10,6 +10,7 @@ from ..mcp import mcp
 from ..config import AuthorDetailFields, ErrorType
 from ..utils.http import make_request
 from ..utils.errors import create_error_response
+from ..utils.logger import logger
 
 @mcp.tool()
 async def author_search(
@@ -279,8 +280,17 @@ async def author_batch_details(
             api_key = get_api_key()
             headers = {"x-api-key": api_key} if api_key else {}
             
+            url = f"{Config.BASE_URL}/author/batch"
+            logger.debug(
+                "Semantic Scholar request: method=%s url=%s params=%s headers=%s",
+                "POST",
+                url,
+                params,
+                headers
+            )
+            logger.debug("Semantic Scholar request body: %s", {"ids": author_ids})
             response = await client.post(
-                f"{Config.BASE_URL}/author/batch",
+                url,
                 params=params,
                 json={"ids": author_ids},
                 headers=headers

--- a/semantic_scholar/api/papers.py
+++ b/semantic_scholar/api/papers.py
@@ -10,6 +10,7 @@ import httpx
 from ..mcp import mcp
 from ..config import PaperFields, CitationReferenceFields, AuthorDetailFields, Config, ErrorType
 from ..utils.http import make_request, get_api_key
+from ..utils.logger import logger
 from ..utils.errors import create_error_response
 
 @mcp.tool()
@@ -513,9 +514,18 @@ async def paper_batch_details(
         async with httpx.AsyncClient(timeout=Config.TIMEOUT) as client:
             api_key = get_api_key()
             headers = {"x-api-key": api_key} if api_key else {}
-            
+
+            url = f"{Config.BASE_URL}/paper/batch"
+            logger.debug(
+                "Semantic Scholar request: method=%s url=%s params=%s headers=%s",
+                "POST",
+                url,
+                params,
+                headers
+            )
+            logger.debug("Semantic Scholar request body: %s", {"ids": paper_ids})
             response = await client.post(
-                f"{Config.BASE_URL}/paper/batch",
+                url,
                 params=params,
                 json={"ids": paper_ids},
                 headers=headers

--- a/semantic_scholar/api/recommendations.py
+++ b/semantic_scholar/api/recommendations.py
@@ -10,6 +10,7 @@ import httpx
 from ..mcp import mcp
 from ..config import Config, ErrorType
 from ..utils.http import rate_limiter, get_api_key
+from ..utils.logger import logger
 from ..utils.errors import create_error_response
 
 @mcp.tool()
@@ -89,6 +90,13 @@ async def get_paper_recommendations_single(
             headers = {"x-api-key": api_key} if api_key else {}
             
             url = f"https://api.semanticscholar.org/recommendations/v1/papers/forpaper/{paper_id}"
+            logger.debug(
+                "Semantic Scholar request: method=%s url=%s params=%s headers=%s",
+                "GET",
+                url,
+                params,
+                headers
+            )
             response = await client.get(url, params=params, headers=headers)
             
             # Handle specific error cases
@@ -123,8 +131,6 @@ async def get_paper_recommendations_single(
             f"Request timed out after {Config.TIMEOUT} seconds"
         )
     except Exception as e:
-        import logging
-        logger = logging.getLogger(__name__)
         logger.error(f"Unexpected error in recommendations: {str(e)}")
         return create_error_response(
             ErrorType.API_ERROR,
@@ -210,6 +216,14 @@ async def get_paper_recommendations_multi(
             headers = {"x-api-key": api_key} if api_key else {}
             
             url = "https://api.semanticscholar.org/recommendations/v1/papers"
+            logger.debug(
+                "Semantic Scholar request: method=%s url=%s params=%s headers=%s",
+                "POST",
+                url,
+                params,
+                headers
+            )
+            logger.debug("Semantic Scholar request body: %s", request_body)
             response = await client.post(url, params=params, json=request_body, headers=headers)
             
             # Handle specific error cases
@@ -247,8 +261,6 @@ async def get_paper_recommendations_multi(
             f"Request timed out after {Config.TIMEOUT} seconds"
         )
     except Exception as e:
-        import logging
-        logger = logging.getLogger(__name__)
         logger.error(f"Unexpected error in recommendations: {str(e)}")
         return create_error_response(
             ErrorType.API_ERROR,

--- a/semantic_scholar/config.py
+++ b/semantic_scholar/config.py
@@ -5,6 +5,7 @@ Configuration for the Semantic Scholar API Server.
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Tuple, Any
+import os
 
 # Rate Limiting Configuration
 @dataclass

--- a/semantic_scholar/config.py
+++ b/semantic_scholar/config.py
@@ -157,7 +157,7 @@ class Config:
     # API Configuration
     API_VERSION = "v1"
     BASE_URL = f"https://api.semanticscholar.org/graph/{API_VERSION}"
-    TIMEOUT = 30  # seconds
+    TIMEOUT = int(os.getenv("SEMANTIC_SCHOLAR_TIMEOUT", "30"))  # seconds
     
     # Request Limits
     MAX_BATCH_SIZE = 100

--- a/semantic_scholar/server.py
+++ b/semantic_scholar/server.py
@@ -14,6 +14,9 @@ from .utils.http import initialize_client, cleanup_client
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Event to keep process alive when FastMCP detaches
+stop_event = None
+
 # Import API modules to register tools
 # Note: This must come AFTER mcp is initialized
 from .api import papers, authors, recommendations
@@ -39,7 +42,32 @@ async def shutdown():
     
     # Cleanup resources
     await cleanup_client()
-    await mcp.cleanup()
+    try:
+        cleanup_fn = getattr(mcp, "cleanup", None)
+        if cleanup_fn:
+            if asyncio.iscoroutinefunction(cleanup_fn):
+                await cleanup_fn()
+            else:
+                cleanup_fn()
+        else:
+            # Try common alternative names on FastMCP implementations
+            for name in ("shutdown", "stop", "close"):
+                fn = getattr(mcp, name, None)
+                if fn:
+                    if asyncio.iscoroutinefunction(fn):
+                        await fn()
+                    else:
+                        fn()
+                    break
+    except Exception as e:
+        logger.error(f"Error during mcp cleanup: {e}")
+    # Signal run_server to stop waiting
+    try:
+        global stop_event
+        if stop_event is not None and not stop_event.is_set():
+            stop_event.set()
+    except Exception:
+        pass
     
     logger.info(f"Cancelled {len(tasks)} tasks")
     logger.info("Shutdown complete")
@@ -52,19 +80,33 @@ def init_signal_handlers(loop):
 
 async def run_server():
     """Run the server with proper async context management."""
-    async with mcp:
-        try:
-            # Initialize HTTP client
-            await initialize_client()
-            
-            # Start the server
-            logger.info("Starting Semantic Scholar Server")
-            await mcp.run_async()
-        except Exception as e:
-            logger.error(f"Server error: {e}")
-            raise
-        finally:
-            await shutdown()
+    try:
+        # Initialize HTTP client
+        await initialize_client()
+
+        # Start the server
+        logger.info("Starting Semantic Scholar Server")
+        task = asyncio.create_task(mcp.run_async())
+
+        # Create a stop event to keep the main coroutine alive if FastMCP detaches
+        global stop_event
+        if stop_event is None:
+            stop_event = asyncio.Event()
+
+        # Wait until shutdown() sets the event
+        await stop_event.wait()
+        # Ensure server task is cancelled/awaited on shutdown
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        raise
+    finally:
+        await shutdown()
 
 def main():
     """Main entry point for the server."""

--- a/semantic_scholar/server.py
+++ b/semantic_scholar/server.py
@@ -2,7 +2,6 @@
 Main server module for the Semantic Scholar API Server.
 """
 
-import logging
 import asyncio
 import signal
 import uvicorn
@@ -10,10 +9,9 @@ import uvicorn
 # Import mcp from centralized location
 from .mcp import mcp
 from .utils.http import initialize_client, cleanup_client
+from .utils.logger import logger
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 # Event to keep process alive when FastMCP detaches
 stop_event = None
@@ -115,6 +113,7 @@ async def run_server():
             host="0.0.0.0",
             port=8000,
             log_level="info",
+            log_config=None,
             ws="none"  # Disable WebSocket support to avoid deprecation warnings
         )
         server = uvicorn.Server(config=config)

--- a/semantic_scholar/utils/logger.py
+++ b/semantic_scholar/utils/logger.py
@@ -1,0 +1,11 @@
+"""
+Centralized logging configuration for the Semantic Scholar server.
+"""
+
+import logging
+import os
+
+DEBUG_REQUESTS = os.getenv("SEMANTIC_SCHOLAR_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+logging.basicConfig(level=logging.DEBUG if DEBUG_REQUESTS else logging.INFO)
+logger = logging.getLogger("semantic_scholar")

--- a/semantic_scholar_server.py
+++ b/semantic_scholar_server.py
@@ -170,7 +170,7 @@ class Config:
     # API Configuration
     API_VERSION = "v1"
     BASE_URL = f"https://api.semanticscholar.org/graph/{API_VERSION}"
-    TIMEOUT = 30  # seconds
+    TIMEOUT = int(os.getenv("SEMANTIC_SCHOLAR_TIMEOUT", "30"))  # seconds
     
     # Request Limits
     MAX_BATCH_SIZE = 100

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -1,0 +1,101 @@
+import asyncio
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+import semantic_scholar.bridge as bridge
+import semantic_scholar.utils.http as utils_http
+
+# Reuse sample IDs from other tests for consistency
+SAMPLE_PAPER_ID = "649def34f8be52c8b66281af98ae884c09aef38b"
+SAMPLE_PAPER_IDS = [
+    SAMPLE_PAPER_ID,
+    "ARXIV:2106.15928"
+]
+SAMPLE_AUTHOR_ID = "1741101"
+SAMPLE_AUTHOR_IDS = [SAMPLE_AUTHOR_ID, "2061296"]
+
+
+@pytest.mark.asyncio
+async def test_paper_search_endpoint(monkeypatch):
+    async def fake_make_request(endpoint, params=None):
+        assert endpoint == "/paper/search"
+        return {"data": [], "total": 0}
+
+    monkeypatch.setattr(bridge, "make_request", fake_make_request)
+
+    transport = ASGITransport(app=bridge.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/v1/paper/search", params={"q": "test", "limit": 1})
+        assert r.status_code == 200
+        body = r.json()
+        assert "data" in body and body["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_paper_details_endpoint(monkeypatch):
+    async def fake_make_request(endpoint, params=None):
+        assert endpoint.startswith("/paper/")
+        return {"paperId": SAMPLE_PAPER_ID, "title": "Test Paper"}
+
+    monkeypatch.setattr(bridge, "make_request", fake_make_request)
+
+    transport = ASGITransport(app=bridge.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get(f"/v1/paper/{SAMPLE_PAPER_ID}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("paperId") == SAMPLE_PAPER_ID
+
+
+@pytest.mark.asyncio
+async def test_paper_batch_endpoint(monkeypatch):
+    # fake http client with a post method
+    class FakeResp:
+        def __init__(self, status_code, data):
+            self.status_code = status_code
+            self._data = data
+            self.text = str(data)
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise Exception("HTTP error")
+
+        def json(self):
+            return self._data
+
+    class FakeClient:
+        async def post(self, url, json=None, params=None):
+            assert isinstance(json, dict) and "ids" in json
+            return FakeResp(200, [{"paperId": pid} for pid in json["ids"]])
+
+    # set the http_client in the utils module used by the bridge
+    monkeypatch.setattr(utils_http, "http_client", FakeClient())
+    transport = ASGITransport(app=bridge.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.post("/v1/paper/batch", json={"ids": SAMPLE_PAPER_IDS})
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body, list) and len(body) == 2
+
+
+@pytest.mark.asyncio
+async def test_author_endpoints_and_recommendations(monkeypatch):
+    async def fake_make_request(endpoint, params=None):
+        if endpoint.startswith("/author/search"):
+            return {"data": [], "total": 0}
+        if endpoint.startswith("/author/") and "batch" not in endpoint:
+            return {"authorId": SAMPLE_AUTHOR_ID, "name": "A. Author"}
+        if endpoint.startswith("/paper/") and endpoint.endswith("/recommendations"):
+            return {"recommendations": []}
+        return {}
+
+    monkeypatch.setattr(bridge, "make_request", fake_make_request)
+
+    transport = ASGITransport(app=bridge.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/v1/author/search", params={"q": "Andrew Ng"})
+        assert r.status_code == 200
+        r = await ac.get(f"/v1/author/{SAMPLE_AUTHOR_ID}")
+        assert r.status_code == 200 and r.json().get("authorId") == SAMPLE_AUTHOR_ID
+        r = await ac.get("/v1/recommendations", params={"paper_id": SAMPLE_PAPER_ID})
+        assert r.status_code == 200 and "recommendations" in r.json()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -17,7 +17,8 @@ SAMPLE_AUTHOR_IDS = [SAMPLE_AUTHOR_ID, "2061296"]
 
 @pytest.mark.asyncio
 async def test_paper_search_endpoint(monkeypatch):
-    async def fake_make_request(endpoint, params=None):
+    async def fake_make_request(*args, **kwargs):
+        endpoint = args[0] if args else kwargs.get('endpoint')
         assert endpoint == "/paper/search"
         return {"data": [], "total": 0}
 
@@ -33,7 +34,8 @@ async def test_paper_search_endpoint(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_paper_details_endpoint(monkeypatch):
-    async def fake_make_request(endpoint, params=None):
+    async def fake_make_request(*args, **kwargs):
+        endpoint = args[0] if args else kwargs.get('endpoint')
         assert endpoint.startswith("/paper/")
         return {"paperId": SAMPLE_PAPER_ID, "title": "Test Paper"}
 
@@ -64,7 +66,7 @@ async def test_paper_batch_endpoint(monkeypatch):
             return self._data
 
     class FakeClient:
-        async def post(self, url, json=None, params=None):
+        async def post(self, url, json=None, params=None, headers=None):
             assert isinstance(json, dict) and "ids" in json
             return FakeResp(200, [{"paperId": pid} for pid in json["ids"]])
 
@@ -80,7 +82,8 @@ async def test_paper_batch_endpoint(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_author_endpoints_and_recommendations(monkeypatch):
-    async def fake_make_request(endpoint, params=None):
+    async def fake_make_request(*args, **kwargs):
+        endpoint = args[0] if args else kwargs.get('endpoint')
         if endpoint.startswith("/author/search"):
             return {"data": [], "total": 0}
         if endpoint.startswith("/author/") and "batch" not in endpoint:


### PR DESCRIPTION
Also updated dependencies and moved in Dockerfile to python 3.12

Also: the semantic scholar API Key can now be provided (on openapi.json-Endpoints) by bearer token. If provided it overrides env-provided API key. So individual users can use its own API Key.

I added two env-variables:
`SEMANTIC_SCHOLAR_DEBUG=true` gives some additional debugging output. With this I moved the logger to utils/logger.py
`SEMANTIC_SCHOLAR_TIMEOUT=30` allows to set a higher timeout from env.

Not sure if this is in the scope of your software piece.