### PR TITLE
fix: resolve server not exiting on Ctrl+C with SSE transport

### DIFF
--- a/semantic_scholar/server.py
+++ b/semantic_scholar/server.py
@@ -4,7 +4,6 @@ Main server module for the Semantic Scholar API Server.
 
 import asyncio
 import os
-import signal
 import uvicorn
 
 # Import mcp from centralized location
@@ -12,91 +11,16 @@ from .mcp import mcp
 from .utils.http import initialize_client, cleanup_client
 from .utils.logger import logger
 
-# Configure logging
-
-# Event to keep process alive when FastMCP detaches
-stop_event = None
-# ASGI HTTP server instance and task (for the bridge)
-http_server = None
-http_server_task = None
-
 # Import API modules to register tools
 # Note: This must come AFTER mcp is initialized
 from .api import papers, authors, recommendations
 
-async def handle_exception(loop, context):
-    """Global exception handler for the event loop."""
-    msg = context.get("exception", context["message"])
-    logger.error(f"Caught exception: {msg}")
-    asyncio.create_task(shutdown())
+_TASK_CANCEL_TIMEOUT = 5  # seconds to wait for tasks to finish on shutdown
 
-async def shutdown():
-    """Gracefully shut down the server."""
-    logger.info("Initiating graceful shutdown...")
-    
-    # Cancel all tasks
-    tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    for task in tasks:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-    
-    # Cleanup resources
-    await cleanup_client()
-    try:
-        cleanup_fn = getattr(mcp, "cleanup", None)
-        if cleanup_fn:
-            if asyncio.iscoroutinefunction(cleanup_fn):
-                await cleanup_fn()
-            else:
-                cleanup_fn()
-        else:
-            # Try common alternative names on FastMCP implementations
-            for name in ("shutdown", "stop", "close"):
-                fn = getattr(mcp, name, None)
-                if fn:
-                    if asyncio.iscoroutinefunction(fn):
-                        await fn()
-                    else:
-                        fn()
-                    break
-    except Exception as e:
-        logger.error(f"Error during mcp cleanup: {e}")
-    # Signal run_server to stop waiting
-    try:
-        global stop_event
-        if stop_event is not None and not stop_event.is_set():
-            stop_event.set()
-    except Exception:
-        pass
-
-    # Stop the HTTP bridge if running
-    try:
-        global http_server, http_server_task
-        if http_server is not None:
-            http_server.should_exit = True
-        if http_server_task is not None and not http_server_task.done():
-            http_server_task.cancel()
-            try:
-                await http_server_task
-            except asyncio.CancelledError:
-                pass
-    except Exception as e:
-        logger.error(f"Error stopping HTTP bridge: {e}")
-    
-    logger.info(f"Cancelled {len(tasks)} tasks")
-    logger.info("Shutdown complete")
-
-def init_signal_handlers(loop):
-    """Initialize signal handlers for graceful shutdown."""
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown()))
-    logger.info("Signal handlers initialized")
 
 async def run_server():
     """Run the server with proper async context management."""
+    tasks: list[asyncio.Task] = []
     try:
         # Initialize HTTP client
         await initialize_client()
@@ -108,11 +32,12 @@ async def run_server():
         logger.info("Starting Semantic Scholar Server (transport=%s)", transport)
 
         if transport in ("sse", "streamable-http"):
-            task = asyncio.create_task(
+            mcp_task = asyncio.create_task(
                 mcp.run_async(transport=transport, host=mcp_host, port=mcp_port)
             )
         else:
-            task = asyncio.create_task(mcp.run_async())
+            mcp_task = asyncio.create_task(mcp.run_async())
+        tasks.append(mcp_task)
 
         # Start the HTTP bridge (ASGI) in the same process so the service
         # exposes REST endpoints on a local port. The `bridge.app` is a thin
@@ -133,60 +58,56 @@ async def run_server():
                 port=bridge_port,
                 log_level="info",
                 log_config=None,
-                ws="none"  # Disable WebSocket support to avoid deprecation warnings
+                ws="none",  # Disable WebSocket support to avoid deprecation warnings
             )
-            server = uvicorn.Server(config=config)
-            global http_server, http_server_task
-            http_server = server
-            http_server_task = asyncio.create_task(server.serve())
+            bridge_server = uvicorn.Server(config=config)
+            tasks.append(asyncio.create_task(bridge_server.serve()))
             logger.info("HTTP bridge enabled on %s:%s", bridge_host, bridge_port)
         else:
             logger.info("HTTP bridge disabled (SEMANTIC_SCHOLAR_ENABLE_HTTP_BRIDGE=0)")
 
-        # Create a stop event to keep the main coroutine alive if FastMCP detaches
-        global stop_event
-        if stop_event is None:
-            stop_event = asyncio.Event()
+        # Wait for any task to finish (e.g. uvicorn exits on Ctrl+C).
+        # When one exits, cancel the rest.
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
-        # Wait until shutdown() sets the event
-        await stop_event.wait()
-        # Ensure server task is cancelled/awaited on shutdown
-        if not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        # Log errors from finished tasks
+        for t in done:
+            if t.exception():
+                logger.error("Task failed: %s", t.exception())
+
+        # Cancel remaining tasks and give them time to finish
+        for t in pending:
+            t.cancel()
+        if pending:
+            await asyncio.wait(pending, timeout=_TASK_CANCEL_TIMEOUT)
+
+    except asyncio.CancelledError:
+        pass
     except Exception as e:
         logger.error(f"Server error: {e}")
         raise
     finally:
-        await shutdown()
+        # Cancel any still-alive tasks (belt-and-suspenders)
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        if any(not t.done() for t in tasks):
+            await asyncio.wait(tasks, timeout=_TASK_CANCEL_TIMEOUT)
+
+        await cleanup_client()
+        logger.info("Shutdown complete")
+
 
 def main():
     """Main entry point for the server."""
     try:
-        # Set up event loop with exception handler
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.set_exception_handler(handle_exception)
-        
-        # Initialize signal handlers
-        init_signal_handlers(loop)
-        
-        # Run the server
-        loop.run_until_complete(run_server())
+        asyncio.run(run_server())
     except KeyboardInterrupt:
         logger.info("Received keyboard interrupt, shutting down...")
     except Exception as e:
         logger.error(f"Fatal error: {str(e)}")
     finally:
-        try:
-            loop.run_until_complete(asyncio.sleep(0))  # Let pending tasks complete
-            loop.close()
-        except Exception as e:
-            logger.error(f"Error during final cleanup: {str(e)}")
         logger.info("Server stopped")
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary

When using SSE/streamable-http transport, `mcp.run_async()` starts uvicorn internally which overwrites the custom signal handlers installed by `init_signal_handlers()`. This meant `stop_event` was never signaled on Ctrl+C, causing the process to hang indefinitely.

I replaced the signal handler + stop_event + shutdown machinery with `asyncio.wait()` on the actual server tasks. Now, when any task finishes (e.g. uvicorn exits on Ctrl+C), remaining tasks are cancelled with a timeout. I also simplified `main()` to use `asyncio.run()` instead of the manual event loop management.

## Checklist

- [x] Scope is focused (one logical change set)
- [x] No secrets included (API keys/tokens removed or redacted)
- [x] Local checks run:
  - [x] `python3 -m pytest -q test/test_bridge.py test/test_rate_limiter.py`
  - [x] (optional) `python3 -m compileall -q semantic_scholar run.py`
- [x] If behavior changes or new env vars were added, `README.md` was updated
- [x] If a server/port is introduced or changed, it is configurable via env (enable/host/port)
- [x] If HTTP code was touched, uses shared helpers in `semantic_scholar/utils/http.py`

## Testing Notes

I haven't run the following tests to avoid making requests to Semantic Scholar:
- test_paper.py
- test_author.py
- test_recommend.pytest_utils.py

However, my changes don't touch any of the code paths that they exercise, so they should be good.
